### PR TITLE
fix(lib): allow es6 modules as Redux actions

### DIFF
--- a/src/components/connector.js
+++ b/src/components/connector.js
@@ -15,7 +15,7 @@ export default function Connector(store) {
 
     let finalMapStateToTarget = mapStateToTarget || defaultMapStateToTarget;
 
-    const finalMapDispatchToTarget = isPlainObject(mapDispatchToTarget) ?
+    const finalMapDispatchToTarget = isObject(mapDispatchToTarget) && !isFunction(mapDispatchToTarget) ?
       wrapActionCreators(mapDispatchToTarget) :
       mapDispatchToTarget || defaultMapDispatchToTarget;
 
@@ -25,7 +25,7 @@ export default function Connector(store) {
       );
 
     invariant(
-      isPlainObject(finalMapDispatchToTarget) || isFunction(finalMapDispatchToTarget),
+      isObject(finalMapDispatchToTarget) || isFunction(finalMapDispatchToTarget),
       'mapDispatchToTarget must be a plain Object or a Function. Instead received %s.', finalMapDispatchToTarget
       );
 

--- a/test/components/connector.spec.js
+++ b/test/components/connector.spec.js
@@ -117,7 +117,8 @@ describe('Connector', () => {
   it('Should allow ES6 modules', () => {
     // The tests are run in Node, so we are unable to use actual ES6 modules. We get quite
     // close by emulating it
-    const fakeModule = new Number(1);
+    class FakeModule {};
+    const fakeModule = new FakeModule();
     fakeModule.prop = () => {};
     expect(connect(() => ({}), fakeModule)(targetObj)).toNotThrow();
   });

--- a/test/components/connector.spec.js
+++ b/test/components/connector.spec.js
@@ -114,6 +114,14 @@ describe('Connector', () => {
     expect(receivedDispatch).toBe(store.dispatch);
   });
 
+  it('Should allow ES6 modules', () => {
+    // The tests are run in Node, so we are unable to use actual ES6 modules. We get quite
+    // close by emulating it
+    const fakeModule = new Number(1);
+    fakeModule.prop = () => {};
+    expect(connect(() => ({}), fakeModule)(targetObj)).toNotThrow();
+  });
+
   it('Should provide state slice, bound actions and previous state slice to target (function)', () => {
     const targetFunc = sinon.spy();
 


### PR DESCRIPTION
Created a PR also to our own fork, just in case the main one (https://github.com/angular-redux/ng-redux/pull/217) doesn't get reviewed fast enough.