### PR TITLE
feat(store creator callback): provide callback for creating store

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,6 +110,12 @@ declare namespace ngRedux {
 
   export interface INgReduxProvider {
     /**
+     * callback for creating Redux store.
+     *
+     * @param storeCreator
+     */
+    createStore<S = any>(storeCreator: (middlewares?: (Middleware | string)[], storeEnhancers?: Function[]) => Store<S>): void;
+    /**
      * Creates Redux store.
      *
      * @param reducer


### PR DESCRIPTION
This allows user to have full control over creating the store. This is important since some enhancers rely on ordering and needs to be first in list. Without having control over store creation this is not possible: ngRedux always sets the middlewares first.

Same pr against the actual ng-redux: https://github.com/angular-redux/ng-redux/pull/218